### PR TITLE
Adds an 'isTime' boolean to each axis returned from cdat.file.variables

### DIFF
--- a/vcs_server/FileLoader.py
+++ b/vcs_server/FileLoader.py
@@ -113,7 +113,8 @@ class FileLoader(protocols.vtkWebProtocol):
                 'units': units,
                 'modulo': axis.getModulo(),
                 'moduloCycle': axis.getModuloCycle(),
-                'data': axis.getData().tolist()
+                'data': axis.getData().tolist(),
+                'isTime': axis.isTime()
             }
         return [outVars, outAxes]
 


### PR DESCRIPTION
vCDAT needs to be able to reliably determine if a given axis describes time. This simply adds a call to .isTime() and returns the value as 'isTime'.

Please let me know if there is anything else that needs to be done to make this change robust. 