### PR TITLE
Add template functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -201,22 +201,37 @@ function getalltemplatenames() {
     });
 }
 
-function gettemplate(template_name) {
+function gettemplate(templateName) {
   const { connection } = connect('server');
   return connection.vtkweb
     .then((client) => {
-      return client.pvw.session.call('vcs.gettemplate', [template_name]);
+      return client.pvw.session.call('vcs.gettemplate', [templateName]);
     });
 }
 
-function settemplate(template_name, template_data) {
+function settemplate(templateName, templateData) {
   const { connection } = connect('server');
   return connection.vtkweb
     .then((client) => {
-      return client.pvw.session.call('vcs.settemplate', [template_name, template_data]);
+      return client.pvw.session.call('vcs.settemplate', [templateName, templateData]);
     });
 }
 
+function createtemplate(templateName, nameSource) {
+  const { connection } = connect('server');
+  return connection.vtkweb
+    .then((client) => {
+      return client.pvw.session.call('vcs.createtemplate', [templateName, nameSource]);
+    });
+}
+
+function removetemplate(templateName) {
+  const { connection } = connect('server');
+  return connection.vtkweb
+    .then((client) => {
+      return client.pvw.session.call('vcs.removetemplate', [templateName]);
+    });
+}
 
 export {
   init,
@@ -241,4 +256,6 @@ export {
   getalltemplatenames,
   gettemplate,
   settemplate,
+  createtemplate,
+  removetemplate,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -193,6 +193,14 @@ function removegraphicsmethod(typeName, name) {
     });
 }
 
+function gettemplates() {
+  const { connection } = connect('server');
+  return connection.vtkweb
+    .then((client) => {
+      return client.pvw.session.call('vcs.gettemplates');
+    });
+}
+
 
 export {
   init,
@@ -213,4 +221,6 @@ export {
   setgraphicsmethod,
   creategraphicsmethod,
   removegraphicsmethod,
+  // Template method functions
+  gettemplates,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -193,11 +193,27 @@ function removegraphicsmethod(typeName, name) {
     });
 }
 
-function gettemplates() {
+function getalltemplatenames() {
   const { connection } = connect('server');
   return connection.vtkweb
     .then((client) => {
-      return client.pvw.session.call('vcs.gettemplates');
+      return client.pvw.session.call('vcs.getalltemplatenames');
+    });
+}
+
+function gettemplate(template_name) {
+  const { connection } = connect('server');
+  return connection.vtkweb
+    .then((client) => {
+      return client.pvw.session.call('vcs.gettemplate', [template_name]);
+    });
+}
+
+function settemplate(template_name, template_data) {
+  const { connection } = connect('server');
+  return connection.vtkweb
+    .then((client) => {
+      return client.pvw.session.call('vcs.settemplate', [template_name, template_data]);
     });
 }
 
@@ -222,5 +238,7 @@ export {
   creategraphicsmethod,
   removegraphicsmethod,
   // Template method functions
-  gettemplates,
+  getalltemplatenames,
+  gettemplate,
+  settemplate,
 };

--- a/test/cases/templates.js
+++ b/test/cases/templates.js
@@ -1,0 +1,143 @@
+/* eslint-disable func-names */
+import { getTestRequirements } from "../util/TestUtils";
+
+describe("templates", function templateTests() {
+  this.timeout(5000);
+
+  it("getsAllTemplateNames", function() {
+    const testName = this.test.title;
+    const { vcs } = getTestRequirements(testName, false);
+    const expectedTemplates = [
+      "URof4_dud",
+      "boldmid_of3_l",
+      "por_topof3_dud",
+      "boldtop_of3_l",
+      "bold_mid_of3",
+      "LRof4_dud",
+      "por_midof3",
+      "no_legend",
+      "ULof4_dud",
+      "MR_of6_1legend",
+      "ML_of6",
+      "por_midof3_dud",
+      "mollweide2",
+      "hovmuller",
+      "URof4",
+      "BLof6",
+      "bot_of2",
+      "LLof4_dud",
+      "LRof4",
+      "ASD_dud",
+      "bold_top_of3",
+      "ASD",
+      "UL_of6_1legend",
+      "ULof4",
+      "ULof6",
+      "polar",
+      "BL_of6_1legend",
+      "ML_of6_1legend",
+      "top_of2",
+      "LLof4",
+      "deftaylor",
+      "UR_of6",
+      "por_botof3",
+      "default",
+      "BR_of6_1legend",
+      "por_botof3_dud",
+      "BRof6",
+      "por_topof3",
+      "MR_of6",
+      "UR_of6_1legend",
+      "boldbot_of3_l",
+      "quick"
+    ];
+
+    return vcs.getalltemplatenames().then(names => {
+      return new Promise((resolve, reject) => {
+        for (let item of expectedTemplates) {
+          if(names.indexOf(item) === -1){
+            reject(new Error(`Expected list of template names to contain '${item}'`));
+          } 
+        }
+        resolve(true)
+      });
+    });
+  });
+
+  it("getsATemplate", function() {
+    const testName = this.test.title;
+    const { vcs } = getTestRequirements(testName, false);
+
+    return vcs.gettemplate("default").then(data => {
+      return new Promise((resolve, reject) => {
+        if(data && data.name === "default"){
+          resolve(true)
+        }
+        reject(new Error('gettemplate did not return the default template'));
+      });
+    });
+  });
+
+  it("getsATemplateReturnsNull", function() {
+    const testName = this.test.title;
+    const { vcs } = getTestRequirements(testName, false);
+
+    return vcs.gettemplate("doesNotExist").then(data => {
+      return new Promise((resolve, reject) => {
+        if(data === null){
+          resolve(true)
+        }
+        reject(new Error('gettemplate should return null if a requested template does not exist'));
+      });
+    });
+  });
+
+  it("settemplate", function() {
+    const testName = this.test.title;
+    const { vcs } = getTestRequirements(testName, false);
+    const newValues = {'ymintic1': {'member': 'ymintic1', 'priority': 0, 'line': 'default'}} // change priority from 1 to 0
+    return vcs.settemplate("ASD", newValues).then(() => {
+      return vcs.gettemplate("ASD").then(data => {
+        return new Promise((resolve, reject) => {
+          if(data && data.name === "ASD" && data.ymintic1.priority === 0){
+            resolve(true)
+          }
+          reject(new Error('settemplate failed to set ymintic1 priority to 0'));
+        });
+      });
+    });
+  });
+
+  it("createsATemplate", function() {
+    const testName = this.test.title;
+    const { vcs } = getTestRequirements(testName, false);
+    const baseTemplateName = "default"
+    const newTemplateName = "testTemplate"
+    return vcs.createtemplate(newTemplateName, baseTemplateName).then(() => {
+      return vcs.gettemplate(newTemplateName).then(data => {
+        return new Promise((resolve, reject) => {
+          if(data && data.name === "testTemplate"){
+            resolve(true)
+          }
+          reject(new Error('createtemplate did not create a template with the given name'));
+        });
+      });
+    });
+  });
+  
+  it("removesATemplate", function() {
+    const testName = this.test.title;
+    const { vcs } = getTestRequirements(testName, false);
+    const templateNameToRemove = "testTemplate"
+    return vcs.removetemplate(templateNameToRemove).then(() => {
+      return vcs.gettemplate(templateNameToRemove).then(data => {
+        return new Promise((resolve, reject) => {
+          if(data === null){
+            resolve(true)
+          }
+          reject(new Error('Got back a template that should have been removed.'));
+        });
+      });
+    });
+  });
+});

--- a/vcs_server/Visualizer.py
+++ b/vcs_server/Visualizer.py
@@ -214,7 +214,6 @@ class Visualizer(protocols.vtkWebProtocol):
     def createtemplate(self, templateName, nameSource):
         base_template = vcs.gettemplate(nameSource)
         vcs.createtemplate(templateName, base_template)
-        return
             
     @exportRpc('vcs.removetemplate')
     def removetemplate(self, templateName):

--- a/vcs_server/Visualizer.py
+++ b/vcs_server/Visualizer.py
@@ -185,21 +185,21 @@ class Visualizer(protocols.vtkWebProtocol):
         return template_list
 
     @exportRpc('vcs.gettemplate')
-    def gettemplate(self, template_name):
-        if(template_name in vcs.elements['template'].keys()):
-            template = vcs.dumpToDict(vcs.elements['template'][template_name])[0]
+    def gettemplate(self, templateName):
+        if(templateName in vcs.elements['template'].keys()):
+            template = vcs.dumpToDict(vcs.elements['template'][templateName])[0]
             return template
         else:
             return None
             
     @exportRpc('vcs.settemplate')
-    def settemplate(self, name, new_values):
+    def settemplate(self, name, newValues):
         template = vcs.gettemplate(name)
-        for outer_key in new_values:
-            if isinstance(new_values[outer_key], dict):
+        for outer_key in newValues:
+            if isinstance(newValues[outer_key], dict):
                 template_inner_obj = getattr(template, outer_key)
-                for inner_name in new_values[outer_key]:
-                    setattr(template_inner_obj, inner_name, new_values[outer_key][inner_name])
+                for inner_name in newValues[outer_key]:
+                    setattr(template_inner_obj, inner_name, newValues[outer_key][inner_name])
                     # Example: 
                     # if template = {'ymintic1': {'member': 'ymintic1', 'priority': 1, 'line': 'default'}}
                     # and new_values = {'ymintic1': {'member': 'ymintic1', 'priority': 0, 'line': 'default'}}
@@ -209,5 +209,15 @@ class Visualizer(protocols.vtkWebProtocol):
                     # inner_name = 'priority'
                     # 
                     # setattr would set template's ymintic1's priority to 0
-                    
+                
+    @exportRpc('vcs.createtemplate')
+    def createtemplate(self, templateName, nameSource):
+        base_template = vcs.gettemplate(nameSource)
+        vcs.createtemplate(templateName, base_template)
+        return
+            
+    @exportRpc('vcs.removetemplate')
+    def removetemplate(self, templateName):
+        template = vcs.gettemplate(templateName)
+        vcs.removeP(template)
 

--- a/vcs_server/Visualizer.py
+++ b/vcs_server/Visualizer.py
@@ -176,3 +176,13 @@ class Visualizer(protocols.vtkWebProtocol):
     def setgraphicsmethod(self, typeName, name, nameValueMap):
         gm = vcs.getgraphicsmethod(typeName, name)
         updateGraphicsMethodProps(nameValueMap, gm)
+
+    # ======================================================================
+    # Template Method routines
+    @exportRpc('vcs.gettemplates')
+    def gettemplates(self):
+        templates = {}
+        for tname in vcs.elements['template'].keys():
+            templates[tname] = vcs.utils.dumpToDict(vcs.elements['template'][tname])[0]
+        return templates
+

--- a/vcs_server/Visualizer.py
+++ b/vcs_server/Visualizer.py
@@ -179,10 +179,35 @@ class Visualizer(protocols.vtkWebProtocol):
 
     # ======================================================================
     # Template Method routines
-    @exportRpc('vcs.gettemplates')
+    @exportRpc('vcs.getalltemplatenames')
     def gettemplates(self):
-        templates = {}
-        for tname in vcs.elements['template'].keys():
-            templates[tname] = vcs.utils.dumpToDict(vcs.elements['template'][tname])[0]
-        return templates
+        template_list = sorted(vcs.elements['template'].keys(), key=lambda s: s.lower())
+        return template_list
+
+    @exportRpc('vcs.gettemplate')
+    def gettemplate(self, template_name):
+        if(template_name in vcs.elements['template'].keys()):
+            template = vcs.dumpToDict(vcs.elements['template'][template_name])[0]
+            return template
+        else:
+            return None
+            
+    @exportRpc('vcs.settemplate')
+    def settemplate(self, name, new_values):
+        template = vcs.gettemplate(name)
+        for outer_key in new_values:
+            if isinstance(new_values[outer_key], dict):
+                template_inner_obj = getattr(template, outer_key)
+                for inner_name in new_values[outer_key]:
+                    setattr(template_inner_obj, inner_name, new_values[outer_key][inner_name])
+                    # Example: 
+                    # if template = {'ymintic1': {'member': 'ymintic1', 'priority': 1, 'line': 'default'}}
+                    # and new_values = {'ymintic1': {'member': 'ymintic1', 'priority': 0, 'line': 'default'}}
+                    #
+                    # template_inner_obj = {'member': 'ymintic1', 'priority': 1, 'line': 'default'}
+                    # outername = 'ymintic1'
+                    # inner_name = 'priority'
+                    # 
+                    # setattr would set template's ymintic1's priority to 0
+                    
 


### PR DESCRIPTION
Fixes #50 

This PR adds basic C.R.U.D. methods for vcs templates. 

It does not deal with the issue of state permanency. Templates, like everything else, is reset if the user restarts the application. Since this is not an issue relating to just templates, a separate issue will need to be made to address this. 